### PR TITLE
Update namespace references to TYPO3incubator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  BASE_IMAGE_NAME: dkd-dobberkau/base
-  DEMO_IMAGE_NAME: dkd-dobberkau/demo
-  CONTRIB_IMAGE_NAME: dkd-dobberkau/contrib
+  BASE_IMAGE_NAME: typo3/base
+  DEMO_IMAGE_NAME: typo3/demo
+  CONTRIB_IMAGE_NAME: typo3/contrib
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -136,14 +136,14 @@ jobs:
           file: Dockerfile.base
           target: ${{ matrix.variant }}
           load: true
-          tags: ghcr.io/dkd-dobberkau/base:8.3-${{ matrix.variant }}
+          tags: ghcr.io/typo3/base:8.3-${{ matrix.variant }}
           build-args: |
             PHP_VERSION=8.3
           cache-from: type=gha
 
       - name: Test PHP extensions
         run: |
-          IMAGE="ghcr.io/dkd-dobberkau/base:8.3-${{ matrix.variant }}"
+          IMAGE="ghcr.io/typo3/base:8.3-${{ matrix.variant }}"
           MODULES=$(docker run --rm --entrypoint php "$IMAGE" -m)
           for ext in gd intl opcache mysqli pdo_mysql pdo_pgsql redis apcu zip; do
             if echo "$MODULES" | grep -qi "$ext"; then
@@ -154,22 +154,22 @@ jobs:
           done
 
       - name: Test Composer
-        run: docker run --rm --entrypoint composer ghcr.io/dkd-dobberkau/base:8.3-${{ matrix.variant }} --version
+        run: docker run --rm --entrypoint composer ghcr.io/typo3/base:8.3-${{ matrix.variant }} --version
 
       - name: Test Nginx config
         if: matrix.variant == 'nginx' || matrix.variant == 'nginx-slim'
         run: |
-          docker run --rm --entrypoint sh ghcr.io/dkd-dobberkau/base:8.3-${{ matrix.variant }} \
+          docker run --rm --entrypoint sh ghcr.io/typo3/base:8.3-${{ matrix.variant }} \
             -c 'sed -i "s|\$TYPO3_CONTEXT|Production|g" /etc/nginx/conf.d/default.conf && nginx -t'
 
       - name: Test GraphicsMagick
         if: matrix.variant == 'nginx' || matrix.variant == 'fpm'
-        run: docker run --rm --entrypoint gm ghcr.io/dkd-dobberkau/base:8.3-${{ matrix.variant }} version | head -1
+        run: docker run --rm --entrypoint gm ghcr.io/typo3/base:8.3-${{ matrix.variant }} version | head -1
 
       - name: Verify NO GraphicsMagick (slim)
         if: matrix.variant == 'nginx-slim' || matrix.variant == 'fpm-slim'
         run: |
-          docker run --rm --entrypoint sh ghcr.io/dkd-dobberkau/base:8.3-${{ matrix.variant }} \
+          docker run --rm --entrypoint sh ghcr.io/typo3/base:8.3-${{ matrix.variant }} \
             -c '! command -v gm' && echo "✓ gm not installed (slim)"
 
   # ---------------------------------------------------------------------------
@@ -387,7 +387,7 @@ jobs:
         run: |
           docker build -f Dockerfile.base \
             --target nginx \
-            -t ghcr.io/dkd-dobberkau/base:8.3-nginx \
+            -t ghcr.io/typo3/base:8.3-nginx \
             --build-arg PHP_VERSION=8.3 \
             .
 
@@ -446,13 +446,13 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'dkd-dobberkau/base:8.3-nginx'
-          - 'dkd-dobberkau/base:8.3-fpm'
-          - 'dkd-dobberkau/base:8.3-nginx-slim'
-          - 'dkd-dobberkau/base:8.3-fpm-slim'
-          - 'dkd-dobberkau/demo:13-php8.3'
-          - 'dkd-dobberkau/demo:13-intro-php8.3'
-          - 'dkd-dobberkau/contrib:8.2'
+          - 'typo3/base:8.3-nginx'
+          - 'typo3/base:8.3-fpm'
+          - 'typo3/base:8.3-nginx-slim'
+          - 'typo3/base:8.3-fpm-slim'
+          - 'typo3/demo:13-php8.3'
+          - 'typo3/demo:13-intro-php8.3'
+          - 'typo3/contrib:8.2'
 
     steps:
       - name: Login to GHCR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing
 
-See the [Contributing Guide](https://dkd-dobberkau.github.io/typo3-base/development/contributing.html) in the documentation.
+See the [Contributing Guide](https://typo3incubator.github.io/typo3-base/development/contributing.html) in the documentation.
 
 For a quick start:
 
 ```bash
-git clone https://github.com/dkd-dobberkau/typo3-base.git
+git clone https://github.com/TYPO3incubator/typo3-base.git
 cd typo3-base
 make build-all
 make test

--- a/Dockerfile.contrib
+++ b/Dockerfile.contrib
@@ -14,7 +14,7 @@
 #   1.) Now you need the `docker-compose.contrib-public.yml` file, get it from
 #       this repository:
 #
-#       $> wget https://raw.githubusercontent.com/dkd-dobberkau/typo3-base/refs/heads/main/docker-compose.contrib-public.yml
+#       $> wget https://raw.githubusercontent.com/TYPO3incubator/typo3-base/refs/heads/main/docker-compose.contrib-public.yml
 #
 #   2.) Now start the docker framework:
 #
@@ -35,7 +35,7 @@ ARG PHP_VERSION=8.2
 # -----------------------------------------------------------------------------
 # Stage 1: Install TYPO3 via Composer
 # -----------------------------------------------------------------------------
-FROM ghcr.io/dkd-dobberkau/base:${PHP_VERSION}-nginx AS build
+FROM ghcr.io/typo3/base:${PHP_VERSION}-nginx AS build
 
 LABEL org.opencontainers.image.title="TYPO3 Contribution Image"
 LABEL org.opencontainers.image.description="Ready-to-run TYPO3 main contribution setup with Apache"

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -16,7 +16,7 @@ ARG TYPO3_DEMO_CONTENT=""
 # -----------------------------------------------------------------------------
 # Stage 1: Install TYPO3 via Composer
 # -----------------------------------------------------------------------------
-FROM ghcr.io/dkd-dobberkau/base:${PHP_VERSION}-nginx AS build
+FROM ghcr.io/typo3/base:${PHP_VERSION}-nginx AS build
 
 ARG TYPO3_VERSION=13
 ARG TYPO3_DEMO_CONTENT=""
@@ -50,7 +50,7 @@ RUN set -eux; \
 # -----------------------------------------------------------------------------
 # Stage 2: Final demo image
 # -----------------------------------------------------------------------------
-FROM ghcr.io/dkd-dobberkau/base:${PHP_VERSION}-nginx
+FROM ghcr.io/typo3/base:${PHP_VERSION}-nginx
 
 ARG TYPO3_VERSION=13
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 PHP_VERSION ?= 8.3
 TYPO3_VERSION ?= 13
-REGISTRY ?= ghcr.io/dkd-dobberkau
+REGISTRY ?= ghcr.io/typo3
 HTTP_PORT ?= 8080
 HTTP_PORT_CONTRIB ?= 28080
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # TYPO3 Official Docker Images
 
-[![Build and Push Docker Images](https://github.com/dkd-dobberkau/typo3-base/actions/workflows/build.yml/badge.svg)](https://github.com/dkd-dobberkau/typo3-base/actions/workflows/build.yml)
+[![Build and Push Docker Images](https://github.com/TYPO3incubator/typo3-base/actions/workflows/build.yml/badge.svg)](https://github.com/TYPO3incubator/typo3-base/actions/workflows/build.yml)
 
 Production-ready Docker images for TYPO3 CMS — Debian Bookworm + PHP (Sury packages). Multi-architecture support: `linux/amd64` + `linux/arm64` (Apple Silicon).
 
-**[Full Documentation](https://dkd-dobberkau.github.io/typo3-base/)**
+**[Full Documentation](https://typo3incubator.github.io/typo3-base/)**
 
 ## Images
 
 | Image | Purpose | Quick Start |
 |-------|---------|-------------|
-| `dkd-dobberkau/base` | Slim runtime — build your project on top | [Base Image Docs](https://dkd-dobberkau.github.io/typo3-base/getting-started/base-image.html) |
-| `dkd-dobberkau/demo` | Pre-installed TYPO3 for demos | `docker compose -f docker-compose.demo.yml up` |
-| `dkd-dobberkau/contrib` | TYPO3 Core contribution environment | [Contrib Docs](https://dkd-dobberkau.github.io/typo3-base/guides/core-contribution.html) |
+| `typo3/base` | Slim runtime — build your project on top | [Base Image Docs](https://typo3incubator.github.io/typo3-base/getting-started/base-image.html) |
+| `typo3/demo` | Pre-installed TYPO3 for demos | `docker compose -f docker-compose.demo.yml up` |
+| `typo3/contrib` | TYPO3 Core contribution environment | [Contrib Docs](https://typo3incubator.github.io/typo3-base/guides/core-contribution.html) |
 
 ## Quick Start
 
@@ -38,9 +38,9 @@ debian:bookworm-slim + Sury PHP
   [fpm]      [nginx]
 :8.3-fpm   :8.3-nginx  <- build targets (--target fpm / --target nginx)
     |         |
-    |   Dockerfile.demo    -> dkd-dobberkau/demo:{TYPO3_VERSION}
+    |   Dockerfile.demo    -> typo3/demo:{TYPO3_VERSION}
     |
-Dockerfile.contrib -> dkd-dobberkau/contrib:{PHP_VERSION}
+Dockerfile.contrib -> typo3/contrib:{PHP_VERSION}
 ```
 
 ## Building Locally
@@ -52,7 +52,7 @@ make test-fpm     # Run smoke tests (fpm variant)
 make demo         # Build and start demo
 ```
 
-See the [full documentation](https://dkd-dobberkau.github.io/typo3-base/) for environment variables, production deployment with Traefik SSL, Kubernetes guides, and more.
+See the [full documentation](https://typo3incubator.github.io/typo3-base/) for environment variables, production deployment with Traefik SSL, Kubernetes guides, and more.
 
 ## Contributing
 

--- a/docker-compose.contrib-public.yml
+++ b/docker-compose.contrib-public.yml
@@ -14,7 +14,7 @@
 
 services:
   web:
-    image: ghcr.io/dkd-dobberkau/contrib:8.2
+    image: ghcr.io/typo3/contrib:8.2
     build:
       context: .
       args:

--- a/docker-compose.contrib.yml
+++ b/docker-compose.contrib.yml
@@ -16,7 +16,7 @@ services:
   web:
     # IMPORTANT: This is the BUILD file for the repository. It requires build artifacts.
     # Check out `docker-compose.contrib-public.yml` to use for your boilerplate. It uses:
-    # image: dkd-dobberkau/contrib
+    # image: typo3/contrib
     build:
       context: .
       dockerfile: Dockerfile.contrib

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,7 @@
 #   2.) Rename .env.prod.example to .env and adjust the values
 #   3.) Build your project image based on the TYPO3 base image:
 #
-#       FROM ghcr.io/dkd-dobberkau/base:8.3-nginx
+#       FROM ghcr.io/typo3/base:8.3-nginx
 #       COPY --chown=typo3:typo3 . /var/www/html
 #
 #   4.) Start the stack:
@@ -52,7 +52,7 @@ services:
   # TYPO3 Web — Your project image
   # ---------------------------------------------------------------------------
   web:
-    image: ghcr.io/dkd-dobberkau/base:${PHP_VERSION:-8.3}-nginx
+    image: ghcr.io/typo3/base:${PHP_VERSION:-8.3}-nginx
     # Uncomment below to build from a local Dockerfile instead:
     # build:
     #   context: .

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -7,5 +7,5 @@ src = "src"
 [output.html]
 default-theme = "light"
 preferred-dark-theme = "navy"
-git-repository-url = "https://github.com/dkd-dobberkau/typo3-base"
-edit-url-template = "https://github.com/dkd-dobberkau/typo3-base/edit/main/docs/{path}"
+git-repository-url = "https://github.com/TYPO3incubator/typo3-base"
+edit-url-template = "https://github.com/TYPO3incubator/typo3-base/edit/main/docs/{path}"

--- a/docs/plans/2026-02-14-mdbook-implementation.md
+++ b/docs/plans/2026-02-14-mdbook-implementation.md
@@ -29,8 +29,8 @@ src = "src"
 [output.html]
 default-theme = "light"
 preferred-dark-theme = "navy"
-git-repository-url = "https://github.com/dkd-dobberkau/typo3-base"
-edit-url-template = "https://github.com/dkd-dobberkau/typo3-base/edit/main/docs/{path}"
+git-repository-url = "https://github.com/TYPO3incubator/typo3-base"
+edit-url-template = "https://github.com/TYPO3incubator/typo3-base/edit/main/docs/{path}"
 ```
 
 **Step 2: Create `docs/src/SUMMARY.md`**
@@ -298,7 +298,7 @@ git commit -m "ci: add GitHub Actions workflow for MDBook deployment"
 Keep: badge, one-paragraph overview, images overview (3 images, 1-liner each), quick start (`docker compose up`), architecture ASCII diagram, "Building Locally" with `make build-all` / `make test`, license.
 
 Replace detailed sections (env vars, volumes, extensions, Dockerfile examples, contrib setup) with links like:
-`See the [full documentation](https://dkd-dobberkau.github.io/typo3-base/) for detailed guides.`
+`See the [full documentation](https://typo3incubator.github.io/typo3-base/) for detailed guides.`
 
 Target: ~100 lines (down from ~329).
 
@@ -309,12 +309,12 @@ Replace body with a short redirect:
 ```markdown
 # Contributing
 
-See the [Contributing Guide](https://dkd-dobberkau.github.io/typo3-base/development/contributing.html) in the documentation.
+See the [Contributing Guide](https://typo3incubator.github.io/typo3-base/development/contributing.html) in the documentation.
 
 For a quick start:
 
 \`\`\`bash
-git clone https://github.com/dkd-dobberkau/typo3-base.git
+git clone https://github.com/TYPO3incubator/typo3-base.git
 cd typo3-base
 make build-all
 make test

--- a/docs/src/development/building.md
+++ b/docs/src/development/building.md
@@ -58,7 +58,7 @@ This builds base images (nginx + fpm) for PHP 8.2/8.3/8.4, demo images for TYPO3
 |----------|---------|-------------|
 | `PHP_VERSION` | `8.3` | PHP version for base image |
 | `TYPO3_VERSION` | `13` | TYPO3 version for demo image |
-| `REGISTRY` | `ghcr.io/dkd-dobberkau` | Container registry |
+| `REGISTRY` | `ghcr.io/typo3` | Container registry |
 | `HTTP_PORT` | `8080` | Host port for demo |
 
 ## Running the Demo

--- a/docs/src/development/contributing.md
+++ b/docs/src/development/contributing.md
@@ -11,7 +11,7 @@ Contributions are welcome! This guide explains how to set up the development env
 ## Getting Started
 
 ```bash
-git clone https://github.com/dkd-dobberkau/typo3-base.git
+git clone https://github.com/TYPO3incubator/typo3-base.git
 cd typo3-base
 ```
 

--- a/docs/src/development/security.md
+++ b/docs/src/development/security.md
@@ -4,11 +4,11 @@
 
 | Image | Tag | Supported |
 |-------|-----|-----------|
-| dkd-dobberkau/base | 8.3-nginx | Yes |
-| dkd-dobberkau/base | 8.4-nginx | Yes |
-| dkd-dobberkau/base | 8.2-nginx | Yes |
-| dkd-dobberkau/demo | 13 | Yes |
-| dkd-dobberkau/demo | 14 | Yes |
+| typo3/base | 8.3-nginx | Yes |
+| typo3/base | 8.4-nginx | Yes |
+| typo3/base | 8.2-nginx | Yes |
+| typo3/demo | 13 | Yes |
+| typo3/demo | 14 | Yes |
 
 ## Reporting a Vulnerability
 

--- a/docs/src/getting-started/base-image.md
+++ b/docs/src/getting-started/base-image.md
@@ -1,6 +1,6 @@
 # Base Image
 
-`dkd-dobberkau/base` is a slim runtime image with PHP-FPM and all required PHP extensions for TYPO3. It does **not** contain TYPO3 itself — you build your project-specific image on top of it.
+`typo3/base` is a slim runtime image with PHP-FPM and all required PHP extensions for TYPO3. It does **not** contain TYPO3 itself — you build your project-specific image on top of it.
 
 ## Variants
 
@@ -27,7 +27,7 @@ Two variants are available:
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM ghcr.io/dkd-dobberkau/base:8.3-nginx AS base
+FROM ghcr.io/typo3/base:8.3-nginx AS base
 FROM composer:2 AS build
 
 WORKDIR /app
@@ -43,7 +43,7 @@ COPY --from=build --chown=typo3:typo3 /app /var/www/html
 ## Usage — FPM Variant (Kubernetes / external web server)
 
 ```dockerfile
-FROM ghcr.io/dkd-dobberkau/base:8.3-fpm
+FROM ghcr.io/typo3/base:8.3-fpm
 COPY --from=build --chown=typo3:typo3 /app /var/www/html
 ```
 
@@ -57,8 +57,8 @@ These images **complement** DDEV — they do not compete with it.
 |----------|-----------------|
 | Local development | **DDEV** |
 | Team development | **DDEV** |
-| CI/CD pipelines | **dkd-dobberkau/base** (fpm variant) |
-| Staging & production | **dkd-dobberkau/base** (with your project) |
-| Kubernetes / Cloud | **dkd-dobberkau/base** (fpm variant) + Helm Charts |
-| Demo & evaluation | **dkd-dobberkau/demo** |
-| TYPO3 Core contribution | **dkd-dobberkau/contrib** |
+| CI/CD pipelines | **typo3/base** (fpm variant) |
+| Staging & production | **typo3/base** (with your project) |
+| Kubernetes / Cloud | **typo3/base** (fpm variant) + Helm Charts |
+| Demo & evaluation | **typo3/demo** |
+| TYPO3 Core contribution | **typo3/contrib** |

--- a/docs/src/getting-started/demo-image.md
+++ b/docs/src/getting-started/demo-image.md
@@ -1,6 +1,6 @@
 # Demo Image
 
-`dkd-dobberkau/demo` is a pre-installed TYPO3 for demos, evaluation, and onboarding. Includes a complete TYPO3 setup ready to start.
+`typo3/demo` is a pre-installed TYPO3 for demos, evaluation, and onboarding. Includes a complete TYPO3 setup ready to start.
 
 ## Available Tags
 

--- a/docs/src/guides/core-contribution.md
+++ b/docs/src/guides/core-contribution.md
@@ -1,6 +1,6 @@
 # Core Contribution
 
-`dkd-dobberkau/contrib` is a ready-to-run environment for contributing to the TYPO3 Core. It uses the FPM base image with a host-side Git checkout of the TYPO3 mono repository, set up as a Composer-based project.
+`typo3/contrib` is a ready-to-run environment for contributing to the TYPO3 Core. It uses the FPM base image with a host-side Git checkout of the TYPO3 mono repository, set up as a Composer-based project.
 
 ## Available Tags
 
@@ -25,7 +25,7 @@ Replace `YOUR_USERNAME` with your [my.typo3.org](https://my.typo3.org) username.
 ### 2. Download the Compose File
 
 ```bash
-curl -O https://raw.githubusercontent.com/dkd-dobberkau/typo3-base/main/docker-compose.contrib.yml
+curl -O https://raw.githubusercontent.com/TYPO3incubator/typo3-base/main/docker-compose.contrib.yml
 ```
 
 ### 3. Start the Environment

--- a/docs/src/guides/kubernetes.md
+++ b/docs/src/guides/kubernetes.md
@@ -1,13 +1,13 @@
 # Kubernetes
 
-> **Coming Soon** — A Helm chart is planned. See the [project roadmap](https://github.com/dkd-dobberkau/typo3-base/blob/main/TODO.md) for progress.
+> **Coming Soon** — A Helm chart is planned. See the [project roadmap](https://github.com/TYPO3incubator/typo3-base/blob/main/TODO.md) for progress.
 
 ## Recommended Setup
 
 For Kubernetes deployments, use the **FPM variant** of the base image:
 
 ```dockerfile
-FROM ghcr.io/dkd-dobberkau/base:8.3-fpm
+FROM ghcr.io/typo3/base:8.3-fpm
 COPY --from=build --chown=typo3:typo3 /app /var/www/html
 ```
 

--- a/docs/src/guides/production-deploy.md
+++ b/docs/src/guides/production-deploy.md
@@ -23,7 +23,7 @@ Create a `Dockerfile` in your TYPO3 project:
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM ghcr.io/dkd-dobberkau/base:8.3-nginx AS base
+FROM ghcr.io/typo3/base:8.3-nginx AS base
 FROM composer:2 AS build
 
 WORKDIR /app
@@ -41,8 +41,8 @@ COPY --from=build --chown=typo3:typo3 /app /var/www/html
 Copy `docker-compose.prod.yml` and `.env.prod.example` from this repository into your project:
 
 ```bash
-curl -O https://raw.githubusercontent.com/dkd-dobberkau/typo3-base/main/docker-compose.prod.yml
-curl -O https://raw.githubusercontent.com/dkd-dobberkau/typo3-base/main/.env.prod.example
+curl -O https://raw.githubusercontent.com/TYPO3incubator/typo3-base/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/TYPO3incubator/typo3-base/main/.env.prod.example
 ```
 
 ## Step 3: Configure Environment
@@ -80,7 +80,7 @@ In `docker-compose.prod.yml`, uncomment the `build` section for the `web` servic
 
 ```yaml
 web:
-  # image: ghcr.io/dkd-dobberkau/base:${PHP_VERSION:-8.3}-nginx
+  # image: ghcr.io/typo3/base:${PHP_VERSION:-8.3}-nginx
   build:
     context: .
     dockerfile: Dockerfile

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,6 +1,6 @@
 # TYPO3 Docker Images
 
-[![Build and Push Docker Images](https://github.com/dkd-dobberkau/typo3-base/actions/workflows/build.yml/badge.svg)](https://github.com/dkd-dobberkau/typo3-base/actions/workflows/build.yml)
+[![Build and Push Docker Images](https://github.com/TYPO3incubator/typo3-base/actions/workflows/build.yml/badge.svg)](https://github.com/TYPO3incubator/typo3-base/actions/workflows/build.yml)
 
 Production-ready Docker images for TYPO3 CMS — Debian Bookworm + PHP (Sury packages).
 
@@ -10,9 +10,9 @@ Multi-architecture support: `linux/amd64` + `linux/arm64` (Apple Silicon).
 
 | Image | Purpose |
 |-------|---------|
-| [`dkd-dobberkau/base`](getting-started/base-image.md) | Slim runtime image with PHP-FPM — build your project on top |
-| [`dkd-dobberkau/demo`](getting-started/demo-image.md) | Pre-installed TYPO3 for demos and evaluation |
-| [`dkd-dobberkau/contrib`](guides/core-contribution.md) | Ready-to-run TYPO3 Core contribution environment |
+| [`typo3/base`](getting-started/base-image.md) | Slim runtime image with PHP-FPM — build your project on top |
+| [`typo3/demo`](getting-started/demo-image.md) | Pre-installed TYPO3 for demos and evaluation |
+| [`typo3/contrib`](guides/core-contribution.md) | Ready-to-run TYPO3 Core contribution environment |
 
 ## Where to Start
 

--- a/docs/src/reference/architecture.md
+++ b/docs/src/reference/architecture.md
@@ -12,9 +12,9 @@ debian:bookworm-slim + Sury PHP
   [fpm]      [nginx]
 :8.3-fpm   :8.3-nginx  <- build targets (--target fpm / --target nginx)
     |         |
-    |   Dockerfile.demo    -> dkd-dobberkau/demo:{TYPO3_VERSION}
+    |   Dockerfile.demo    -> typo3/demo:{TYPO3_VERSION}
     |
-Dockerfile.contrib -> dkd-dobberkau/contrib:{PHP_VERSION}
+Dockerfile.contrib -> typo3/contrib:{PHP_VERSION}
 ```
 
 ## Variants
@@ -63,5 +63,5 @@ The optional `TYPO3_DEMO_CONTENT=introduction` build arg adds the Introduction P
 | `PHP_VERSION` | `8.3` | Both Dockerfiles, Makefile |
 | `TYPO3_VERSION` | `13` | Dockerfile.demo, Makefile |
 | `TYPO3_DEMO_CONTENT` | `""` | Dockerfile.demo (set to `introduction` for intro variant) |
-| `REGISTRY` | `ghcr.io/dkd-dobberkau` | Makefile |
+| `REGISTRY` | `ghcr.io/typo3` | Makefile |
 | `HTTP_PORT` | `8080` | Makefile (demo) |


### PR DESCRIPTION
## Summary

- Updates all repository references from `dkd-dobberkau/typo3-base` to `TYPO3incubator/typo3-base`
- Updates GitHub Pages URLs from `dkd-dobberkau.github.io` to `typo3incubator.github.io`
- Updates container image names from `dkd-dobberkau/{base,demo,contrib}` to `typo3/{base,demo,contrib}`
- Updates registry path from `ghcr.io/dkd-dobberkau` to `ghcr.io/typo3`

Closes #29

## Test plan

- [ ] Verify no remaining `dkd-dobberkau` references: `grep -r dkd-dobberkau .`
- [ ] Verify `make build-base` uses correct registry
- [ ] Verify CI workflow builds push to `ghcr.io/typo3`
- [ ] Verify documentation links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)