### PR TITLE
Fix CI: update all namespace references to TYPO3incubator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  BASE_IMAGE_NAME: typo3/base
-  DEMO_IMAGE_NAME: typo3/demo
-  CONTRIB_IMAGE_NAME: typo3/contrib
+  BASE_IMAGE_NAME: typo3incubator/base
+  DEMO_IMAGE_NAME: typo3incubator/demo
+  CONTRIB_IMAGE_NAME: typo3incubator/contrib
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -136,14 +136,14 @@ jobs:
           file: Dockerfile.base
           target: ${{ matrix.variant }}
           load: true
-          tags: ghcr.io/typo3/base:8.3-${{ matrix.variant }}
+          tags: ghcr.io/typo3incubator/base:8.3-${{ matrix.variant }}
           build-args: |
             PHP_VERSION=8.3
           cache-from: type=gha
 
       - name: Test PHP extensions
         run: |
-          IMAGE="ghcr.io/typo3/base:8.3-${{ matrix.variant }}"
+          IMAGE="ghcr.io/typo3incubator/base:8.3-${{ matrix.variant }}"
           MODULES=$(docker run --rm --entrypoint php "$IMAGE" -m)
           for ext in gd intl opcache mysqli pdo_mysql pdo_pgsql redis apcu zip; do
             if echo "$MODULES" | grep -qi "$ext"; then
@@ -154,22 +154,22 @@ jobs:
           done
 
       - name: Test Composer
-        run: docker run --rm --entrypoint composer ghcr.io/typo3/base:8.3-${{ matrix.variant }} --version
+        run: docker run --rm --entrypoint composer ghcr.io/typo3incubator/base:8.3-${{ matrix.variant }} --version
 
       - name: Test Nginx config
         if: matrix.variant == 'nginx' || matrix.variant == 'nginx-slim'
         run: |
-          docker run --rm --entrypoint sh ghcr.io/typo3/base:8.3-${{ matrix.variant }} \
+          docker run --rm --entrypoint sh ghcr.io/typo3incubator/base:8.3-${{ matrix.variant }} \
             -c 'sed -i "s|\$TYPO3_CONTEXT|Production|g" /etc/nginx/conf.d/default.conf && nginx -t'
 
       - name: Test GraphicsMagick
         if: matrix.variant == 'nginx' || matrix.variant == 'fpm'
-        run: docker run --rm --entrypoint gm ghcr.io/typo3/base:8.3-${{ matrix.variant }} version | head -1
+        run: docker run --rm --entrypoint gm ghcr.io/typo3incubator/base:8.3-${{ matrix.variant }} version | head -1
 
       - name: Verify NO GraphicsMagick (slim)
         if: matrix.variant == 'nginx-slim' || matrix.variant == 'fpm-slim'
         run: |
-          docker run --rm --entrypoint sh ghcr.io/typo3/base:8.3-${{ matrix.variant }} \
+          docker run --rm --entrypoint sh ghcr.io/typo3incubator/base:8.3-${{ matrix.variant }} \
             -c '! command -v gm' && echo "✓ gm not installed (slim)"
 
   # ---------------------------------------------------------------------------
@@ -387,7 +387,7 @@ jobs:
         run: |
           docker build -f Dockerfile.base \
             --target nginx \
-            -t ghcr.io/typo3/base:8.3-nginx \
+            -t ghcr.io/typo3incubator/base:8.3-nginx \
             --build-arg PHP_VERSION=8.3 \
             .
 
@@ -446,13 +446,13 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'typo3/base:8.3-nginx'
-          - 'typo3/base:8.3-fpm'
-          - 'typo3/base:8.3-nginx-slim'
-          - 'typo3/base:8.3-fpm-slim'
-          - 'typo3/demo:13-php8.3'
-          - 'typo3/demo:13-intro-php8.3'
-          - 'typo3/contrib:8.2'
+          - 'typo3incubator/base:8.3-nginx'
+          - 'typo3incubator/base:8.3-fpm'
+          - 'typo3incubator/base:8.3-nginx-slim'
+          - 'typo3incubator/base:8.3-fpm-slim'
+          - 'typo3incubator/demo:13-php8.3'
+          - 'typo3incubator/demo:13-intro-php8.3'
+          - 'typo3incubator/contrib:8.2'
 
     steps:
       - name: Login to GHCR

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,7 +5,7 @@
 # This image does NOT contain TYPO3 itself. It provides the runtime environment.
 # Build your project image on top of this:
 #
-#   FROM ghcr.io/typo3/base:8.3-nginx
+#   FROM ghcr.io/typo3incubator/base:8.3-nginx
 #   COPY --from=build /app /var/www/html
 #
 # Variants available (--target):

--- a/Dockerfile.contrib
+++ b/Dockerfile.contrib
@@ -35,7 +35,7 @@ ARG PHP_VERSION=8.2
 # -----------------------------------------------------------------------------
 # Stage 1: Install TYPO3 via Composer
 # -----------------------------------------------------------------------------
-FROM ghcr.io/typo3/base:${PHP_VERSION}-nginx AS build
+FROM ghcr.io/typo3incubator/base:${PHP_VERSION}-nginx AS build
 
 LABEL org.opencontainers.image.title="TYPO3 Contribution Image"
 LABEL org.opencontainers.image.description="Ready-to-run TYPO3 main contribution setup with Apache"

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -5,7 +5,7 @@
 # Usage:
 #   docker compose -f docker-compose.demo.yml up
 #   # or standalone with external database:
-#   docker run -p 8080:80 -e TYPO3_DB_HOST=... ghcr.io/typo3/demo:13
+#   docker run -p 8080:80 -e TYPO3_DB_HOST=... ghcr.io/typo3incubator/demo:13
 #
 # =============================================================================
 
@@ -16,7 +16,7 @@ ARG TYPO3_DEMO_CONTENT=""
 # -----------------------------------------------------------------------------
 # Stage 1: Install TYPO3 via Composer
 # -----------------------------------------------------------------------------
-FROM ghcr.io/typo3/base:${PHP_VERSION}-nginx AS build
+FROM ghcr.io/typo3incubator/base:${PHP_VERSION}-nginx AS build
 
 ARG TYPO3_VERSION=13
 ARG TYPO3_DEMO_CONTENT=""
@@ -50,7 +50,7 @@ RUN set -eux; \
 # -----------------------------------------------------------------------------
 # Stage 2: Final demo image
 # -----------------------------------------------------------------------------
-FROM ghcr.io/typo3/base:${PHP_VERSION}-nginx
+FROM ghcr.io/typo3incubator/base:${PHP_VERSION}-nginx
 
 ARG TYPO3_VERSION=13
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 PHP_VERSION ?= 8.3
 TYPO3_VERSION ?= 13
-REGISTRY ?= ghcr.io/typo3
+REGISTRY ?= ghcr.io/typo3incubator
 HTTP_PORT ?= 8080
 HTTP_PORT_CONTRIB ?= 28080
 

--- a/docker-compose.contrib-public.yml
+++ b/docker-compose.contrib-public.yml
@@ -14,7 +14,7 @@
 
 services:
   web:
-    image: ghcr.io/typo3/contrib:8.2
+    image: ghcr.io/typo3incubator/contrib:8.2
     build:
       context: .
       args:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,7 @@
 #   2.) Rename .env.prod.example to .env and adjust the values
 #   3.) Build your project image based on the TYPO3 base image:
 #
-#       FROM ghcr.io/typo3/base:8.3-nginx
+#       FROM ghcr.io/typo3incubator/base:8.3-nginx
 #       COPY --chown=typo3:typo3 . /var/www/html
 #
 #   4.) Start the stack:
@@ -52,7 +52,7 @@ services:
   # TYPO3 Web — Your project image
   # ---------------------------------------------------------------------------
   web:
-    image: ghcr.io/typo3/base:${PHP_VERSION:-8.3}-nginx
+    image: ghcr.io/typo3incubator/base:${PHP_VERSION:-8.3}-nginx
     # Uncomment below to build from a local Dockerfile instead:
     # build:
     #   context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       dockerfile: Dockerfile
       # Your project Dockerfile should look like:
       #
-      #   FROM ghcr.io/typo3/base:8.3-nginx AS base
+      #   FROM ghcr.io/typo3incubator/base:8.3-nginx AS base
       #   FROM composer:2 AS build
       #   WORKDIR /app
       #   COPY composer.json composer.lock ./

--- a/docs/src/development/building.md
+++ b/docs/src/development/building.md
@@ -58,7 +58,7 @@ This builds base images (nginx + fpm) for PHP 8.2/8.3/8.4, demo images for TYPO3
 |----------|---------|-------------|
 | `PHP_VERSION` | `8.3` | PHP version for base image |
 | `TYPO3_VERSION` | `13` | TYPO3 version for demo image |
-| `REGISTRY` | `ghcr.io/typo3` | Container registry |
+| `REGISTRY` | `ghcr.io/typo3incubator` | Container registry |
 | `HTTP_PORT` | `8080` | Host port for demo |
 
 ## Running the Demo

--- a/docs/src/getting-started/base-image.md
+++ b/docs/src/getting-started/base-image.md
@@ -27,7 +27,7 @@ Two variants are available:
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM ghcr.io/typo3/base:8.3-nginx AS base
+FROM ghcr.io/typo3incubator/base:8.3-nginx AS base
 FROM composer:2 AS build
 
 WORKDIR /app
@@ -43,7 +43,7 @@ COPY --from=build --chown=typo3:typo3 /app /var/www/html
 ## Usage — FPM Variant (Kubernetes / external web server)
 
 ```dockerfile
-FROM ghcr.io/typo3/base:8.3-fpm
+FROM ghcr.io/typo3incubator/base:8.3-fpm
 COPY --from=build --chown=typo3:typo3 /app /var/www/html
 ```
 

--- a/docs/src/guides/kubernetes.md
+++ b/docs/src/guides/kubernetes.md
@@ -7,7 +7,7 @@
 For Kubernetes deployments, use the **FPM variant** of the base image:
 
 ```dockerfile
-FROM ghcr.io/typo3/base:8.3-fpm
+FROM ghcr.io/typo3incubator/base:8.3-fpm
 COPY --from=build --chown=typo3:typo3 /app /var/www/html
 ```
 

--- a/docs/src/guides/production-deploy.md
+++ b/docs/src/guides/production-deploy.md
@@ -23,7 +23,7 @@ Create a `Dockerfile` in your TYPO3 project:
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-FROM ghcr.io/typo3/base:8.3-nginx AS base
+FROM ghcr.io/typo3incubator/base:8.3-nginx AS base
 FROM composer:2 AS build
 
 WORKDIR /app
@@ -80,7 +80,7 @@ In `docker-compose.prod.yml`, uncomment the `build` section for the `web` servic
 
 ```yaml
 web:
-  # image: ghcr.io/typo3/base:${PHP_VERSION:-8.3}-nginx
+  # image: ghcr.io/typo3incubator/base:${PHP_VERSION:-8.3}-nginx
   build:
     context: .
     dockerfile: Dockerfile

--- a/docs/src/reference/architecture.md
+++ b/docs/src/reference/architecture.md
@@ -63,5 +63,5 @@ The optional `TYPO3_DEMO_CONTENT=introduction` build arg adds the Introduction P
 | `PHP_VERSION` | `8.3` | Both Dockerfiles, Makefile |
 | `TYPO3_VERSION` | `13` | Dockerfile.demo, Makefile |
 | `TYPO3_DEMO_CONTENT` | `""` | Dockerfile.demo (set to `introduction` for intro variant) |
-| `REGISTRY` | `ghcr.io/typo3` | Makefile |
+| `REGISTRY` | `ghcr.io/typo3incubator` | Makefile |
 | `HTTP_PORT` | `8080` | Makefile (demo) |


### PR DESCRIPTION
## Summary
- Update `DEMO_IMAGE_NAME` and `CONTRIB_IMAGE_NAME` in CI workflow from `typo3/` to `typo3incubator/`
- Update all remaining namespace references from `dkd-dobberkau` to `TYPO3incubator` across Dockerfiles, compose files, Makefile, and docs

Fixes the `permission_denied: The requested installation does not exist` errors on all `build-demo`, `build-demo-intro`, and `build-contrib` CI jobs.

## Test plan
- [ ] CI build-demo jobs push successfully to `ghcr.io/typo3incubator/demo`
- [ ] CI build-contrib jobs push successfully to `ghcr.io/typo3incubator/contrib`
- [ ] CI build-demo-intro jobs push successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)